### PR TITLE
Lang en_us: fix "End Integral Components" name

### DIFF
--- a/src/main/resources/assets/thermal_extra/lang/en_us.json
+++ b/src/main/resources/assets/thermal_extra/lang/en_us.json
@@ -69,7 +69,7 @@
   "item.thermal_extra.drownium_plate": "Drownium Plate",
   "item.thermal_extra.dragon_breath_plating": "Dragon Breath Plating",
   "item.thermal_extra.cactus_dust": "Cactus Dust",
-  "item.thermal_extra.dragon_integral_component": "End Integral Component",
+  "item.thermal_extra.dragon_integral_component": "End Integral Components",
   "item.thermal_extra.dragon_integral_component.desc": "Improves base attributes. Other augments may be more effective as a result.",
   "item.thermal_extra.augment_base": "Augment Base",
   "item.thermal_extra.advanced_augment_base": "Advanced Augment Base",


### PR DESCRIPTION
The *integral components* are all using plural in original Thermal Series.

Fixed for consistency

~~I cannot find their translation file to add a source link to verify.~~ And sorry about the EOL change, github web :/

Edit: See #10 that was declined?

Edit2: Proof https://github.com/CoFH/ThermalCore/blob/9155eecb3d1bb21bbd9254d2c7d2cc6e35e9fcdf/src/main/resources/assets/thermal/lang/en_us.json#L367